### PR TITLE
Update ember GTFS static url

### DIFF
--- a/bustimes/management/commands/import_gtfs_ember.py
+++ b/bustimes/management/commands/import_gtfs_ember.py
@@ -40,7 +40,7 @@ class Command(BaseCommand):
         path = settings.DATA_DIR / Path("ember_gtfs.zip")
 
         source = DataSource.objects.get(name="Ember")
-        source.url = "https://api.ember.to/v1/gtfs/static/"
+        source.url = "https://cdn.ember.to/gtfs/static/Ember_GTFS_latest.zip"
 
         modified, last_modified = download_if_modified(path, source)
         assert modified


### PR DESCRIPTION
Update Ember GTFS URL because Ember's GTFS static link has changed.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb649015-c143-4923-9446-89e4b60ac333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fb649015-c143-4923-9446-89e4b60ac333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

